### PR TITLE
Add shortcode for easier embedding of meshery designs

### DIFF
--- a/layouts/shortcodes/meshery-design-embed.html
+++ b/layouts/shortcodes/meshery-design-embed.html
@@ -1,5 +1,5 @@
 <!-- 
-  This shortcode is used to embed a Meshery design into web pages. 
+  This shortcode is used to embed a Meshery design into hugo sites 
   Meshery Design Embedding allows exporting a design as an interactive component 
   that integrates seamlessly into websites, blogs, or any platform supporting HTML, CSS, and JavaScript. 
   This embedded design is interactive, making it easier for infrastructure stakeholders 

--- a/layouts/shortcodes/meshery-design-embed.html
+++ b/layouts/shortcodes/meshery-design-embed.html
@@ -1,0 +1,60 @@
+<!-- 
+  This shortcode is used to embed a Meshery design into web pages. 
+  Meshery Design Embedding allows exporting a design as an interactive component 
+  that integrates seamlessly into websites, blogs, or any platform supporting HTML, CSS, and JavaScript. 
+  This embedded design is interactive, making it easier for infrastructure stakeholders 
+  to visualize, explore, and collaborate on service mesh designs.
+  
+  -- Usage: 
+  {{< meshery-design-embed src="path/to/embed.js" id="unique-id" style="custom-styles" >}}
+
+  More Information: 
+  Learn more about embedding Meshery designs at:
+  https://docs.layer5.io/kanvas/designer/embedding-designs/
+-->
+
+<!-- 
+  Retrieve the path to the JavaScript file generated for embedding the Meshery design.
+  This script is generated when exporting a design from kanvas.new.
+  The `src` attribute specifies the script location, as provided by the user. 
+-->
+{{ $script := .Get "src" }}
+
+<!-- 
+  Retrieve the unique ID for the embedded Meshery design. 
+  This ID is typically generated when creating the embed code and is used to uniquely 
+  identify the container for the embedded design on the page.
+-->
+{{ $id := .Get "id" }}
+
+<!-- 
+  Retrieve optional custom styles for the embedding container.
+  If not provided, a default style will be applied to ensure proper rendering. 
+-->
+{{ $style := .Get "style" }}
+
+<!-- 
+  Embedding Container: 
+  A `div` element is dynamically created with the provided or default styles. 
+  - The `id` attribute links to the unique design embed.
+  - The `style` attribute can be customized or fall back to a default appearance, 
+    which includes:
+      - Height: 30rem
+      - Width: 100% (responsive to container width)
+      - Border: 1px solid #eee (light border for visibility)
+-->
+<div
+    id="{{ $id }}"
+    {{ if $style }}
+    style="{{ $style }}"
+    {{ else }}
+    style="height: 30rem; width: 100%; border: 1px solid #eee"
+    {{ end }}
+></div>
+
+<!-- 
+  Embed Script: 
+  The JavaScript file (retrieved from the `src` attribute) is included here.
+  - The `type="module"` ensures the script runs in a modern ES6 module context.
+-->
+<script src="{{ $script }}" type="module"></script>


### PR DESCRIPTION

This pull request introduces a new shortcode that allows embedding interactive architecture diagrams created using [Meshery Kanvas](https://kanvas.new). These embeddings are particularly useful for showcasing cloud-native architectures, enabling users to integrate visually rich, interactive designs directly into their documentation, blog posts, and architecture pages.

#### Usage:
Here’s how to use the new shortcode in your Markdown files:

```html
{{< meshery-design src="path/to/your/embed.js" id="unique-design-id" style="height: 40rem; width: 80%;" >}}
```

- **`src`**: Path to the exported JavaScript file generated from Meshery Kanvas.
- **`id`**: Unique ID for the container element.
- **`style`**: Customize the container style as needed. Defaults to a responsive layout if omitted.

#### Benefits:
- **Interactive Visualization**: Replace static images with dynamic, interactive designs.
- **Consistency in Architecture Documentation**: Ensure that stakeholders view and interact with standardized designs directly within the site.

#### Additional Notes:
- Full details on creating and exporting designs in Kanvas can be found in the [official documentation](https://docs.layer5.io/kanvas/designer/embedding-designs/)
