### PR TITLE
Update discussion links to point to tab repo

### DIFF
--- a/content/en/architectures/adobe/index.md
+++ b/content/en/architectures/adobe/index.md
@@ -304,4 +304,4 @@ A rich and seamless developer experience acts as a developer productivity multip
 
 ## Discussion
 
-End user members may participate in the [discussion thread](https://github.com/cncf/enduser-private/discussions/79) for this architecture.
+End user members may participate in the [discussion thread](https://github.com/cncf/tab/discussions/138) for this architecture.

--- a/content/en/architectures/cern-scientific-computing/index.md
+++ b/content/en/architectures/cern-scientific-computing/index.md
@@ -279,4 +279,4 @@ A key goal of our architecture was ensure the complete functionality is availabl
 
 ## Discussion
 
-End user members may participate in the [discussion thread](https://github.com/cncf/enduser-private/discussions/84) for this architecture.
+End user members may participate in the [discussion thread](https://github.com/cncf/tab/discussions/137) for this architecture.

--- a/content/en/architectures/swisscom-cloud-native-telco/index.md
+++ b/content/en/architectures/swisscom-cloud-native-telco/index.md
@@ -339,4 +339,4 @@ The architecture evolved significantly from traditional imperative automation to
 
 ## Discussion
 
-End user members may participate in the [discussion thread](https://github.com/cncf/enduser-private/discussions/85) for this architecture.
+End user members may participate in the [discussion thread](https://github.com/cncf/tab/discussions/136) for this architecture.

--- a/content/en/architectures/swisscom-kubernetes-service/index.md
+++ b/content/en/architectures/swisscom-kubernetes-service/index.md
@@ -283,4 +283,4 @@ By pursuing these initiatives, we aim to continue delivering value to our custom
 
 ## Discussion
 
-End user members may participate in the [discussion thread](https://github.com/cncf/enduser-private/discussions/87) for this architecture.
+End user members may participate in the [discussion thread](https://github.com/cncf/tab/discussions/134) for this architecture.

--- a/content/en/architectures/zeiss/index.md
+++ b/content/en/architectures/zeiss/index.md
@@ -167,4 +167,4 @@ By adopting this cloud-native stack, we have built a highly scalable and future-
 We are constantly investigating how to run our services as efficiently and economically as possible. A near-term priority is replacing our existing Ingress NGINX setup. Because the Kubernetes project has [officially announced the retirement of the ingress-nginx project](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/), we are actively evaluating alternatives—including NGINX Gateway Fabric, Envoy Gateway, and Traefik—while striving to preserve our routing behavior, TLS automation, and operational stability. Transitioning to the Gateway API is a key step in future-proofing our external traffic routing.
 
 ## Discussion
-End user members may participate in the [discussion thread](https://github.com/cncf/enduser-private/discussions/86) for this architecture.
+End user members may participate in the [discussion thread](https://github.com/cncf/tab/discussions/135) for this architecture.


### PR DESCRIPTION
needed to update these links now that the discussions were moved to the public tab repo.